### PR TITLE
Fix: Raise ValueError for insufficient funds in withdraw method

### DIFF
--- a/bank_account/bank_account.py
+++ b/bank_account/bank_account.py
@@ -1,0 +1,12 @@
+class BankAccount:
+    def __init__(self, account_number, balance=0):
+        self.account_number = account_number
+        self.balance = balance
+
+    def deposit(self, amount):
+        self.balance += amount
+
+    def withdraw(self, amount):
+        if amount > self.balance:
+            raise ValueError("Insufficient funds")
+        self.balance -= amount

--- a/tests/test_bank_account.py
+++ b/tests/test_bank_account.py
@@ -1,0 +1,19 @@
+import pytest
+from bank_account.bank_account import BankAccount
+
+def test_deposit():
+    account = BankAccount("12345")
+    account.deposit(100)
+    assert account.balance == 100
+
+
+def test_withdraw_sufficient_funds():
+    account = BankAccount("12345", 100)
+    account.withdraw(50)
+    assert account.balance == 50
+
+
+def test_withdraw_insufficient_funds():
+    account = BankAccount("12345", 100)
+    with pytest.raises(ValueError, match="Insufficient funds"):
+        account.withdraw(150)


### PR DESCRIPTION
The withdraw method raises a ValueError when there are insufficient funds.